### PR TITLE
Fix/checkout

### DIFF
--- a/.github/workflows/build-install-test-snap.yaml
+++ b/.github/workflows/build-install-test-snap.yaml
@@ -11,7 +11,7 @@ on:
         type: string
 
 jobs:
-  triage:
+  build-install-test-snap:
     runs-on: ubuntu-latest
     outputs:
       snap-file: ${{ steps.build-snap.outputs.snap }}

--- a/.github/workflows/build-install-test-snap.yaml
+++ b/.github/workflows/build-install-test-snap.yaml
@@ -30,5 +30,5 @@ jobs:
         snap info ${{ inputs.snap-name }}
     - uses: actions/upload-artifact@v3
       with:
-        name: ${{ inputs.snap-name }}
+        name: ${{ inputs.snap-name }}-${{ inputs.branch-name }}
         path: ${{ steps.build-snap.outputs.snap }}

--- a/.github/workflows/build-install-test-snap.yaml
+++ b/.github/workflows/build-install-test-snap.yaml
@@ -16,7 +16,7 @@ jobs:
     outputs:
       snap-file: ${{ steps.build-snap.outputs.snap }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         ref: '${{ inputs.branch-name }}'
     - uses: snapcore/action-build@v1


### PR DESCRIPTION
- Use the newest version of checkout to avoid the warning about JS
- change job name
- upload with the name including the branch (so we can distinguish the different snaps)