### PR TITLE
fix(branch-name): remove slashes

### DIFF
--- a/.github/workflows/build-install-test-snap.yaml
+++ b/.github/workflows/build-install-test-snap.yaml
@@ -28,7 +28,12 @@ jobs:
     # Do some testing with the snap
     - run: |
         snap info ${{ inputs.snap-name }}
+    # Get branch name without forbidden character
+    - name: Branch name
+      id: branch-name
+      run: |
+        echo "BRANCH_NAME=$(echo ${{ inputs.branch-name }} | sed "s|\/|\-|")" >> "$GITHUB_OUTPUT"
     - uses: actions/upload-artifact@v3
       with:
-        name: ${{ inputs.snap-name }}-${{ inputs.branch-name }}
+        name: ${{ inputs.snap-name }}-${{ steps.branch-name.outputs.BRANCH_NAME }}
         path: ${{ steps.build-snap.outputs.snap }}


### PR DESCRIPTION
slashes in filename are not possible.
I added a step to remove slashes (possibly in the future we might also want to remove other character).
This was tested here: https://github.com/ubuntu-robotics/snap_configuration/actions/runs/7384406580/job/20087291367?pr=16