### PR TITLE
F add lxc template

### DIFF
--- a/.github/workflows/build-install-test-snap-lxc.yaml
+++ b/.github/workflows/build-install-test-snap-lxc.yaml
@@ -59,25 +59,24 @@ jobs:
     - name: Launch container
       run: |
         lxc launch '${{ inputs.lxc-image }}' lxc-container
-        sleep 10
     - name: Push snap to lxc container
       run: |
         cd ${{ inputs.snap-name }}-${{ inputs.branch-name }}
-        lxc file push ${{ inputs.snap-name }}_*.snap lxc-container/
+        lxc file push ${{ inputs.snap-name }}_*.snap lxc-container/root/
     - name: Install snap with flags
       if: inputs.snap-install-args != ''
       run: |
         lxc list
-        lxc exec lxc-container -- sh -c "cd .. && sudo snap install ${{ inputs.snap-name }}_*.snap '${{ inputs.snap-install-args }}'"
+        lxc exec lxc-container -- sh -c "sudo snap install ${{ inputs.snap-name }}_*.snap '${{ inputs.snap-install-args }}'"
     - name: Install snap without flags
       if: inputs.snap-install-args == ''
       run: |
-        lxc exec lxc-container -- sh -c "cd .. && sudo snap install ${{ inputs.snap-name }}_*.snap"
+        lxc exec lxc-container -- sh -c "sudo snap install ${{ inputs.snap-name }}_*.snap"
     - name: Run custom test script
       shell: bash
       run: |
         cat > test-script.sh << 'EOF'
           ${{ inputs.test-script }}
         EOF
-        lxc file push test-script.sh lxc-container/
-        lxc exec lxc-container -- sh -c "cd .. && bash /test-script.sh"
+        lxc file push test-script.sh lxc-container/root/
+        lxc exec lxc-container -- sh -c "bash /test-script.sh"

--- a/.github/workflows/build-install-test-snap-lxc.yaml
+++ b/.github/workflows/build-install-test-snap-lxc.yaml
@@ -39,6 +39,7 @@ jobs:
     uses: ubuntu-robotics/snap_workflows/.github/workflows/build-install-test-snap.yaml@main
     with:
       ubuntu-image: ${{ inputs.ubuntu-image }}
+      snapcraft-channel: ${{ inputs.snapcraft-channel }}
       branch-name: ${{ inputs.branch-name }}
       snap-name: ${{ inputs.snap-name }}
       snap-install-args: ${{ inputs.snap-install-args }}

--- a/.github/workflows/build-install-test-snap-lxc.yaml
+++ b/.github/workflows/build-install-test-snap-lxc.yaml
@@ -54,30 +54,28 @@ jobs:
         path: .
     - name: Setup LXD
       uses: canonical/setup-lxd@v0.1.1
-      with:
-        channel: latest/stable
     - name: Launch container
       run: |
         lxc launch '${{ inputs.lxc-image }}' lxc-container
-        sleep 10 ## TODO(investigate): without sleep the next steps are flaky
+        lxc exec lxc-container -- cloud-init status --wait
     - name: Push snap to lxc container
       run: |
         cd ${{ inputs.snap-name }}-${{ inputs.branch-name }}
-        lxc file push ${{ inputs.snap-name }}_*.snap lxc-container/root/
+        lxc file push ${{ inputs.snap-name }}_*.snap lxc-container/home/ubuntu/
     - name: Install snap with flags
       if: inputs.snap-install-args != ''
       run: |
         lxc list
-        lxc exec lxc-container -- sh -c "sudo snap install ${{ inputs.snap-name }}_*.snap '${{ inputs.snap-install-args }}'"
+        lxc exec lxc-container -- sh -c "sudo snap install /home/ubuntu/${{ inputs.snap-name }}_*.snap '${{ inputs.snap-install-args }}'"
     - name: Install snap without flags
       if: inputs.snap-install-args == ''
       run: |
-        lxc exec lxc-container -- sh -c "sudo snap install ${{ inputs.snap-name }}_*.snap"
+        lxc exec lxc-container -- sh -c "sudo snap install /home/ubuntu/${{ inputs.snap-name }}_*.snap"
     - name: Run custom test script
       shell: bash
       run: |
         cat > test-script.sh << 'EOF'
           ${{ inputs.test-script }}
         EOF
-        lxc file push test-script.sh lxc-container/root/
+        lxc file push test-script.sh lxc-container/home/ubuntu/
         lxc exec lxc-container -- sh -c "bash test-script.sh"

--- a/.github/workflows/build-install-test-snap-lxc.yaml
+++ b/.github/workflows/build-install-test-snap-lxc.yaml
@@ -1,0 +1,90 @@
+name: build-install-test-snap-lxc
+
+on:
+  workflow_call:
+    inputs:
+      lxc-image:
+        required: true
+        type: string
+      snapcraft-channel:
+        required: false
+        type: string
+        default: "latest/stable"
+      snap-name:
+        required: true
+        type: string
+      branch-name:
+        required: true
+        type: string
+      snapcraft-args:
+        required: false
+        type: string
+      snap-install-args:
+        required: false
+        type: string
+      enable-experimental-extensions-env:
+        required: false
+        type: boolean
+      test-script:
+        description: "Custom script to run some custom snap testing"
+        required: false
+        type: string
+
+jobs:
+  build-install-test-snap:
+    runs-on: ubuntu-latest
+    outputs:
+      snap-file: ${{ steps.build-snap.outputs.snap }}
+    steps:
+    - name: Setup LXD
+      uses: canonical/setup-lxd@v0.1.1
+      with:
+        channel: latest/stable
+    - name: Launch container
+      run: |
+        lxc launch '${{ inputs.lxc-image }}' lxc-container
+    - uses: actions/checkout@v4
+      with:
+        ref: '${{ inputs.branch-name }}'
+    - uses: snapcore/action-build@v1
+      env:
+        SNAPCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS : '${{ inputs.enable-experimental-extensions-env }}'
+      with:
+        snapcraft-channel: '${{ inputs.snapcraft-channel }}'
+        snapcraft-args: '${{ inputs.snapcraft-args }}'
+      id: build-snap
+    - name: Push snap to lxc container
+      run: |
+        lxc file push ${{ steps.build-snap.outputs.snap }} lxc-container/home/ubuntu/
+    # Make sure the snap is installable
+    - name: Install snap with flags
+      if: inputs.snap-install-args != ''
+      run: |
+        lxc exec lxc-container -- sudo snap install ${{ steps.build-snap.outputs.snap }} '${{ inputs.snap-install-args }}'
+    - name: Install snap without flags
+      if: inputs.snap-install-args == ''
+      run: |
+        lxc exec lxc-container -- sudo snap install ${{ steps.build-snap.outputs.snap }}
+  
+    - name: Run custom test script
+      if: inputs.test-script != ''
+      shell: bash
+      run: |
+        cat > test-script.sh << 'EOF'
+          ${{ inputs.test-script }}
+        EOF
+        lxc exec lxc-container -- test-script.sh
+    # Do some default testing with the snap
+    - name: Test info snap
+      if: inputs.test-script == ''
+      run: |
+        lxc exec lxc-container -- snap info ${{ inputs.snap-name }}
+    # Get branch name without forbidden character
+    - name: Branch name
+      id: branch-name
+      run: |
+        echo "BRANCH_NAME=$(echo ${{ inputs.branch-name }} | sed "s|\/|\-|")" >> "$GITHUB_OUTPUT"
+    - uses: actions/upload-artifact@v3
+      with:
+        name: ${{ inputs.snap-name }}-${{ steps.branch-name.outputs.BRANCH_NAME }}
+        path: ${{ steps.build-snap.outputs.snap }}

--- a/.github/workflows/build-install-test-snap-lxc.yaml
+++ b/.github/workflows/build-install-test-snap-lxc.yaml
@@ -60,11 +60,11 @@ jobs:
     - name: Install snap with flags
       if: inputs.snap-install-args != ''
       run: |
-        lxc exec lxc-container -- sudo snap install ${{ steps.build-snap.outputs.snap }} '${{ inputs.snap-install-args }}'
+        lxc exec lxc-container -- sudo snap install /home/ubuntu/${{ steps.build-snap.outputs.snap }} '${{ inputs.snap-install-args }}'
     - name: Install snap without flags
       if: inputs.snap-install-args == ''
       run: |
-        lxc exec lxc-container -- sudo snap install ${{ steps.build-snap.outputs.snap }}
+        lxc exec lxc-container -- sudo snap install /home/ubuntu/${{ steps.build-snap.outputs.snap }}
   
     - name: Run custom test script
       if: inputs.test-script != ''
@@ -73,7 +73,8 @@ jobs:
         cat > test-script.sh << 'EOF'
           ${{ inputs.test-script }}
         EOF
-        lxc exec lxc-container -- test-script.sh
+        lxc file push test-script.sh lxc-container/home/ubuntu/
+        lxc exec lxc-container -- bash /home/ubuntu/test-script.sh
     # Do some default testing with the snap
     - name: Test info snap
       if: inputs.test-script == ''

--- a/.github/workflows/build-install-test-snap-lxc.yaml
+++ b/.github/workflows/build-install-test-snap-lxc.yaml
@@ -80,4 +80,4 @@ jobs:
           ${{ inputs.test-script }}
         EOF
         lxc file push test-script.sh lxc-container/root/
-        lxc exec lxc-container -- sh -c "bash /test-script.sh"
+        lxc exec lxc-container -- sh -c "bash test-script.sh"

--- a/.github/workflows/build-install-test-snap-lxc.yaml
+++ b/.github/workflows/build-install-test-snap-lxc.yaml
@@ -69,11 +69,11 @@ jobs:
     - name: Install snap with flags
       if: inputs.snap-install-args != ''
       run: |
-        lxc exec --user ubuntu lxc-container -- sudo snap install /home/ubuntu/${{ inputs.snap-name }}_*.snap '${{ inputs.snap-install-args }}'
+        lxc exec lxc-container -- sh -c "sudo snap install /home/ubuntu/${{ inputs.snap-name }}_*.snap '${{ inputs.snap-install-args }}'"
     - name: Install snap without flags
       if: inputs.snap-install-args == ''
       run: |
-        lxc exec --user ubuntu lxc-container -- sudo snap install /home/ubuntu/${{ inputs.snap-name }}_*.snap
+        lxc exec lxc-container -- sh -c "sudo snap install /home/ubuntu/${{ inputs.snap-name }}_*.snap"
     - name: Run custom test script
       shell: bash
       run: |
@@ -81,4 +81,4 @@ jobs:
           ${{ inputs.test-script }}
         EOF
         lxc file push test-script.sh lxc-container/home/ubuntu/
-        lxc exec --user ubuntu lxc-container -- bash /home/ubuntu/test-script.sh
+        lxc exec lxc-container -- sh -c "bash /home/ubuntu/test-script.sh"

--- a/.github/workflows/build-install-test-snap-lxc.yaml
+++ b/.github/workflows/build-install-test-snap-lxc.yaml
@@ -49,6 +49,7 @@ jobs:
     needs: build
     steps:
     - uses: actions/download-artifact@v3
+      name: ${{ inputs.snap-name }}-${{ inputs.branch-name }}
       with:
         path: .
     - name: Setup LXD
@@ -58,25 +59,25 @@ jobs:
     - name: Launch container
       run: |
         lxc launch '${{ inputs.lxc-image }}' lxc-container
-    - uses: actions/checkout@v4
-      with:
-        ref: '${{ inputs.branch-name }}'
+        sleep 10
     - name: Push snap to lxc container
       run: |
-        lxc file push ${{needs.build.outputs.snap-file}} lxc-container/home/ubuntu/
+        cd ${{ inputs.snap-name }}-${{ inputs.branch-name }}
+        lxc file push ${{ inputs.snap-name }}_*.snap lxc-container/
     - name: Install snap with flags
       if: inputs.snap-install-args != ''
       run: |
-        lxc exec lxc-container -- sudo snap install /home/ubuntu/${{needs.build.outputs.snap-file}} '${{ inputs.snap-install-args }}'
+        lxc list
+        lxc exec lxc-container -- sh -c "cd .. && sudo snap install ${{ inputs.snap-name }}_*.snap '${{ inputs.snap-install-args }}'"
     - name: Install snap without flags
       if: inputs.snap-install-args == ''
       run: |
-        lxc exec lxc-container -- sudo snap install /home/ubuntu/${{needs.build.outputs.snap-file}}
+        lxc exec lxc-container -- sh -c "cd .. && sudo snap install ${{ inputs.snap-name }}_*.snap"
     - name: Run custom test script
       shell: bash
       run: |
         cat > test-script.sh << 'EOF'
           ${{ inputs.test-script }}
         EOF
-        lxc file push test-script.sh lxc-container/home/ubuntu/
-        lxc exec lxc-container -- bash /home/ubuntu/test-script.sh
+        lxc file push test-script.sh lxc-container/
+        lxc exec lxc-container -- sh -c "cd .. && bash /test-script.sh"

--- a/.github/workflows/build-install-test-snap-lxc.yaml
+++ b/.github/workflows/build-install-test-snap-lxc.yaml
@@ -59,6 +59,7 @@ jobs:
     - name: Launch container
       run: |
         lxc launch '${{ inputs.lxc-image }}' lxc-container
+        sleep 10 ## TODO(investigate): without sleep the next steps are flaky
     - name: Push snap to lxc container
       run: |
         cd ${{ inputs.snap-name }}-${{ inputs.branch-name }}

--- a/.github/workflows/build-install-test-snap-lxc.yaml
+++ b/.github/workflows/build-install-test-snap-lxc.yaml
@@ -6,6 +6,10 @@ on:
       lxc-image:
         required: true
         type: string
+      ubuntu-image:
+        required: false
+        type: string
+        default: "ubuntu-latest"
       snapcraft-channel:
         required: false
         type: string
@@ -31,11 +35,21 @@ on:
         type: string
 
 jobs:
-  build-install-test-snap:
+  build:
+    uses: ubuntu-robotics/snap_workflows/.github/workflows/build-install-test-snap.yaml@main
+    with:
+      ubuntu-image: ${{ inputs.ubuntu-image }}
+      branch-name: ${{ inputs.branch-name }}
+      snap-name: ${{ inputs.snap-name }}
+      snap-install-args: ${{ inputs.snap-install-args }}
+
+  test-on-lxc:
     runs-on: ubuntu-latest
-    outputs:
-      snap-file: ${{ steps.build-snap.outputs.snap }}
+    needs: build
     steps:
+    - uses: actions/download-artifact@v3
+      with:
+        path: .
     - name: Setup LXD
       uses: canonical/setup-lxd@v0.1.1
       with:
@@ -46,28 +60,18 @@ jobs:
     - uses: actions/checkout@v4
       with:
         ref: '${{ inputs.branch-name }}'
-    - uses: snapcore/action-build@v1
-      env:
-        SNAPCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS : '${{ inputs.enable-experimental-extensions-env }}'
-      with:
-        snapcraft-channel: '${{ inputs.snapcraft-channel }}'
-        snapcraft-args: '${{ inputs.snapcraft-args }}'
-      id: build-snap
     - name: Push snap to lxc container
       run: |
-        lxc file push ${{ steps.build-snap.outputs.snap }} lxc-container/home/ubuntu/
-    # Make sure the snap is installable
+        lxc file push ${{needs.build.outputs.snap-file}} lxc-container/home/ubuntu/
     - name: Install snap with flags
       if: inputs.snap-install-args != ''
       run: |
-        lxc exec lxc-container -- sudo snap install /home/ubuntu/${{ steps.build-snap.outputs.snap }} '${{ inputs.snap-install-args }}'
+        lxc exec lxc-container -- sudo snap install /home/ubuntu/${{needs.build.outputs.snap-file}} '${{ inputs.snap-install-args }}'
     - name: Install snap without flags
       if: inputs.snap-install-args == ''
       run: |
-        lxc exec lxc-container -- sudo snap install /home/ubuntu/${{ steps.build-snap.outputs.snap }}
-  
+        lxc exec lxc-container -- sudo snap install /home/ubuntu/${{needs.build.outputs.snap-file}}
     - name: Run custom test script
-      if: inputs.test-script != ''
       shell: bash
       run: |
         cat > test-script.sh << 'EOF'
@@ -75,17 +79,3 @@ jobs:
         EOF
         lxc file push test-script.sh lxc-container/home/ubuntu/
         lxc exec lxc-container -- bash /home/ubuntu/test-script.sh
-    # Do some default testing with the snap
-    - name: Test info snap
-      if: inputs.test-script == ''
-      run: |
-        lxc exec lxc-container -- snap info ${{ inputs.snap-name }}
-    # Get branch name without forbidden character
-    - name: Branch name
-      id: branch-name
-      run: |
-        echo "BRANCH_NAME=$(echo ${{ inputs.branch-name }} | sed "s|\/|\-|")" >> "$GITHUB_OUTPUT"
-    - uses: actions/upload-artifact@v3
-      with:
-        name: ${{ inputs.snap-name }}-${{ steps.branch-name.outputs.BRANCH_NAME }}
-        path: ${{ steps.build-snap.outputs.snap }}

--- a/.github/workflows/build-install-test-snap-lxc.yaml
+++ b/.github/workflows/build-install-test-snap-lxc.yaml
@@ -64,8 +64,7 @@ jobs:
         done
     - name: Push snap to lxc container
       run: |
-        cd ${{ inputs.snap-name }}-${{ inputs.branch-name }}
-        lxc file push ${{ inputs.snap-name }}_*.snap lxc-container/home/ubuntu/
+        lxc file push ${{ inputs.snap-name }}-${{ inputs.branch-name }}/${{ inputs.snap-name }}_*.snap lxc-container/home/ubuntu/
     - name: Install snap with flags
       if: inputs.snap-install-args != ''
       run: |

--- a/.github/workflows/build-install-test-snap-lxc.yaml
+++ b/.github/workflows/build-install-test-snap-lxc.yaml
@@ -58,6 +58,10 @@ jobs:
       run: |
         lxc launch '${{ inputs.lxc-image }}' lxc-container
         lxc exec lxc-container -- cloud-init status --wait
+        until lxc exec lxc-container -- getent passwd ubuntu; do
+          echo "Waiting for the ubuntu user."
+          sleep 0.25
+        done
     - name: Push snap to lxc container
       run: |
         cd ${{ inputs.snap-name }}-${{ inputs.branch-name }}
@@ -65,12 +69,11 @@ jobs:
     - name: Install snap with flags
       if: inputs.snap-install-args != ''
       run: |
-        lxc list
-        lxc exec lxc-container -- sudo snap install /home/ubuntu/${{ inputs.snap-name }}_*.snap '${{ inputs.snap-install-args }}'
+        lxc exec --user ubuntu lxc-container -- sudo snap install /home/ubuntu/${{ inputs.snap-name }}_*.snap '${{ inputs.snap-install-args }}'
     - name: Install snap without flags
       if: inputs.snap-install-args == ''
       run: |
-        lxc exec lxc-container -- sudo snap install /home/ubuntu/${{ inputs.snap-name }}_*.snap
+        lxc exec --user ubuntu lxc-container -- sudo snap install /home/ubuntu/${{ inputs.snap-name }}_*.snap
     - name: Run custom test script
       shell: bash
       run: |
@@ -78,4 +81,4 @@ jobs:
           ${{ inputs.test-script }}
         EOF
         lxc file push test-script.sh lxc-container/home/ubuntu/
-        lxc exec lxc-container -- bash /home/ubuntu/test-script.sh
+        lxc exec --user ubuntu lxc-container -- bash /home/ubuntu/test-script.sh

--- a/.github/workflows/build-install-test-snap-lxc.yaml
+++ b/.github/workflows/build-install-test-snap-lxc.yaml
@@ -66,11 +66,11 @@ jobs:
       if: inputs.snap-install-args != ''
       run: |
         lxc list
-        lxc exec lxc-container -- sh -c "sudo snap install /home/ubuntu/${{ inputs.snap-name }}_*.snap '${{ inputs.snap-install-args }}'"
+        lxc exec lxc-container -- sudo snap install /home/ubuntu/${{ inputs.snap-name }}_*.snap '${{ inputs.snap-install-args }}'
     - name: Install snap without flags
       if: inputs.snap-install-args == ''
       run: |
-        lxc exec lxc-container -- sh -c "sudo snap install /home/ubuntu/${{ inputs.snap-name }}_*.snap"
+        lxc exec lxc-container -- sudo snap install /home/ubuntu/${{ inputs.snap-name }}_*.snap
     - name: Run custom test script
       shell: bash
       run: |
@@ -78,4 +78,4 @@ jobs:
           ${{ inputs.test-script }}
         EOF
         lxc file push test-script.sh lxc-container/home/ubuntu/
-        lxc exec lxc-container -- sh -c "bash test-script.sh"
+        lxc exec lxc-container -- bash /home/ubuntu/test-script.sh


### PR DESCRIPTION
Add a template to run workflows in a LXC container. This is especially useful for running test on EOL distros such as ubuntu 18.04 which are depracated to run in github actions.