### PR TITLE
optional branch-name in workflow

### DIFF
--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -15,7 +15,7 @@ on:
         required: true
         type: string
       branch-name:
-        required: true
+        required: false
         type: string
         default: "main"
       snapcraft-args:


### PR DESCRIPTION
The `branch-name` parameter shouldn't be `required` since it has a default value.