### PR TITLE
Install dangerous by default

### DIFF
--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -28,6 +28,7 @@ on:
       snap-install-args:
         required: false
         type: string
+        default: "--dangerous"
       enable-experimental-extensions-env:
         required: false
         type: boolean


### PR DESCRIPTION
Since the workflow installs the snap it has just built, it probably should use `--dangerous` by default