### PR TITLE
fix(store_login): use input instead of secret

### DIFF
--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -54,7 +54,7 @@ on:
     secrets:
       store-login:
         description: "Snap Store credential exported with snapcraft export-login"
-        required: true
+        required: false
 
 jobs:
   build:

--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -51,7 +51,10 @@ on:
         required: false
         type: boolean
         default: true
-
+    secrets:
+      store-login:
+        description: "Snap Store credential exported with snapcraft export-login"
+        required: true
 
 jobs:
   build:
@@ -125,7 +128,7 @@ jobs:
     - name: Publish snap
       uses: snapcore/action-publish@v1
       env:
-        SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
+        SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.store-login }}
       if: env.SNAPCRAFT_STORE_CREDENTIALS
       with:
         snap: ${{needs.build.outputs.snap-file}}


### PR DESCRIPTION
reusable workflows cannot access secret from the calling workflow. Secrets have to be passed via inputs as described here: https://docs.github.com/en/actions/using-workflows/reusing-workflows#using-inputs-and-secrets-in-a-reusable-workflow